### PR TITLE
Add Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,6 @@ lazy val baseSettings = Seq(
   ),
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-core" % catsVersion,
-    "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0",
     "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
     "org.scalatest" %% "scalatest" % "3.2.9" % Test,
     "org.typelevel" %% "cats-laws" % catsVersion % Test,
@@ -112,10 +111,8 @@ lazy val util = project
   .settings(moduleName := "catbird-util")
   .settings(allSettings)
   .settings(
-    libraryDependencies ++=
-      Seq(
-        ("com.twitter" %% "util-core" % utilVersion).exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
-      ),
+    libraryDependencies +=
+      ("com.twitter" %% "util-core" % utilVersion).cross(CrossVersion.for3Use2_13),
     (Test / scalacOptions) ~= {
       _.filterNot(Set("-Yno-imports", "-Yno-predef"))
     }
@@ -155,11 +152,11 @@ lazy val finagle = project
   .settings(moduleName := "catbird-finagle")
   .settings(allSettings)
   .settings(
-    libraryDependencies +=
-      ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13)
-        .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
-        .exclude("org.scala-lang.modules", "scala-parser-combinators_2.13")
-        .exclude("com.twitter", "util-core_2.13"),
+    libraryDependencies ++=
+      Seq(
+        ("com.twitter" %% "util-core" % utilVersion).cross(CrossVersion.for3Use2_13),
+        ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13)
+      ),
     (Test / scalacOptions) ~= {
       _.filterNot(Set("-Yno-imports", "-Yno-predef"))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -152,11 +152,8 @@ lazy val finagle = project
   .settings(moduleName := "catbird-finagle")
   .settings(allSettings)
   .settings(
-    libraryDependencies ++=
-      Seq(
-        ("com.twitter" %% "util-core" % utilVersion).cross(CrossVersion.for3Use2_13),
-        ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13)
-      ),
+    libraryDependencies +=
+      ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13),
     (Test / scalacOptions) ~= {
       _.filterNot(Set("-Yno-imports", "-Yno-predef"))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,11 @@ lazy val finagle = project
   .settings(moduleName := "catbird-finagle")
   .settings(allSettings)
   .settings(
-    libraryDependencies += ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13),
+    libraryDependencies +=
+      ("com.twitter" %% "finagle-core" % finagleVersion).cross(CrossVersion.for3Use2_13)
+        .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
+        .exclude("org.scala-lang.modules", "scala-parser-combinators_2.13")
+        .exclude("com.twitter", "util-core_2.13"),
     (Test / scalacOptions) ~= {
       _.filterNot(Set("-Yno-imports", "-Yno-predef"))
     }

--- a/util/src/main/scala/io/catbird/util/Rerunnable.scala
+++ b/util/src/main/scala/io/catbird/util/Rerunnable.scala
@@ -153,10 +153,16 @@ final object Rerunnable extends RerunnableInstances1 {
         rerunnableInstance
 
       final override val sequential: Rerunnable.Par ~> Rerunnable =
-        λ[Rerunnable.Par ~> Rerunnable](Rerunnable.Par.unwrap(_))
+        new ~>[Rerunnable.Par, Rerunnable] {
+          def apply[A](fa: Rerunnable.Par[A]): Rerunnable[A] =
+            Rerunnable.Par.unwrap[A](fa)
+        }
 
       final override val parallel: Rerunnable ~> Rerunnable.Par =
-        λ[Rerunnable ~> Rerunnable.Par](Rerunnable.Par(_))
+        new ~>[Rerunnable, Rerunnable.Par] {
+          def apply[A](fa: Rerunnable[A]): Rerunnable.Par[A] =
+            Rerunnable.Par(fa)
+        }
     }
 
   /**
@@ -190,7 +196,11 @@ final object Rerunnable extends RerunnableInstances1 {
    * [[https://typelevel.org/cats-tagless/ cats-tagless]] in a codebase that mixes [[Rerunnable]] and
    * [[Future]].
    */
-  final val toFuture: Rerunnable ~> Future = λ[Rerunnable ~> Future](_.run)
+  final val toFuture: Rerunnable ~> Future =
+    new ~>[Rerunnable, Future] {
+      def apply[A](fa: Rerunnable[A]): Future[A] =
+        fa.run
+    }
 }
 
 private[util] trait RerunnableInstances1 extends RerunnableParallelNewtype {

--- a/util/src/main/scala/io/catbird/util/future.scala
+++ b/util/src/main/scala/io/catbird/util/future.scala
@@ -67,9 +67,15 @@ trait FutureInstances extends FutureInstances1 {
       final override val monad: Monad[Future] =
         twitterFutureInstance
 
-      final override val sequential: FuturePar ~> Future = λ[FuturePar ~> Future](FuturePar.unwrap(_))
+      final override val sequential: FuturePar ~> Future =
+        new ~>[FuturePar, Future] {
+          def apply[A](fa: FuturePar[A]): Future[A] = FuturePar.unwrap(fa)
+        }
 
-      final override val parallel: Future ~> FuturePar = λ[Future ~> FuturePar](FuturePar(_))
+      final override val parallel: Future ~> FuturePar =
+        new ~>[Future, FuturePar] {
+          def apply[A](fa: Future[A]): FuturePar[A] = FuturePar(fa)
+        }
     }
 }
 


### PR DESCRIPTION
Because `finagle` is not published for Scala 3 we are using the `for3Use2_13` option.