### PR TITLE
Setup versioning and MiMa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - run: sbt '++${{ matrix.scala }}' clean coverage test scalastyle scalafmtCheckAll scalafmtSbtCheck unidoc coverageReport
+      - run: sbt '++${{ matrix.scala }}' clean coverage test mimaReportBinaryIssues scalastyle scalafmtCheckAll scalafmtSbtCheck unidoc coverageReport
 
       - name: Code coverage analysis
         uses: codecov/codecov-action@v1

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,8 @@ val catsVersion = "2.7.0"
 val finagleVersion = "21.8.0"
 
 ThisBuild / tlBaseVersion := BaseVersion(finagleVersion)
-ThisBuild / tlMimaPreviousVersions := Set.empty
-
-// Finagle releases monthly using a {year}.{month}.{patch} version scheme.
-// The combination of year and month is effectively a major version, because
-// each monthly release often contains binary-incompatible changes.
-// This means we should release at least monthly as well, when Finagle does,
-// but in between those monthly releases, maintain binary compatibility.
-ThisBuild / versionScheme := Option("year-month-patch")
+ThisBuild / tlVersionIntroduced := // test bincompat starting from the beginning of this series
+  List("2.12", "2.13").map(_ -> s"${BaseVersion(finagleVersion)}.0").toMap
 
 // For the transition period, we publish artifacts for both cats-effect 2.x and 3.x
 val catsEffectVersion = "2.5.5"
@@ -22,6 +16,14 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 val docMappingsApiDir = settingKey[String]("Subdirectory in site target directory for API docs")
 
 lazy val baseSettings = Seq(
+  // Finagle releases monthly using a {year}.{month}.{patch} version scheme.
+  // The combination of year and month is effectively a major version, because
+  // each monthly release often contains binary-incompatible changes.
+  // This means we should release at least monthly as well, when Finagle does,
+  // but in between those monthly releases, maintain binary compatibility.
+  // This is effectively PVP style versioning.
+  // We set this at the project-level instead of ThisBuild to circumvent sbt-typelevel checks.
+  versionScheme := Some("pvp"),
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-core" % catsVersion,
     "org.scalacheck" %% "scalacheck" % "1.16.0" % Test,
@@ -137,6 +139,7 @@ ThisBuild / githubWorkflowBuild := Seq(
       "clean",
       "coverage",
       "test",
+      "mimaReportBinaryIssues",
       "scalastyle",
       "scalafmtCheckAll",
       "scalafmtSbtCheck",

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val finagleVersion = "21.8.0"
 
 ThisBuild / tlBaseVersion := BaseVersion(finagleVersion)
 ThisBuild / tlVersionIntroduced := // test bincompat starting from the beginning of this series
-  List("2.12", "2.13").map(_ -> s"${BaseVersion(finagleVersion)}.0").toMap
+  List("2.12", "2.13").map(_ -> s"${tlBaseVersion.value}.0").toMap
 
 // For the transition period, we publish artifacts for both cats-effect 2.x and 3.x
 val catsEffectVersion = "2.5.5"


### PR DESCRIPTION
This executes the versioning strategy described in https://github.com/typelevel/catbird/pull/460#discussion_r886171665.

> I'm leaning towards continuing to use the year.month.patch scheme in this repo, in part to keep things inline with Finagle, and in part because I'm not sure what version we'd start with if we switched over to another scheme, like early-semver. (e.g. if we switched to 1.0.0, then Scala Steward is going to consider 21.8.0 to be the newest version for a long time.)
> 
> If we continue to use year.month.patch, then I would consider year.month to be the major version, meaning we should feel free to break bincompat with each monthly release, but we maintain bincompat within a month if we make subsequent releases.

Edit: this part below is a bit trickier :)

> If we can make it happen, I'd like to take it a step further and only introduce a break in a given month if Finagle or Twitter Utils also introduces a break, but I don't know if that's strictly necessary.