### PR TITLE
add CODEOWNERS file to indicate who has maintainer authority in this repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bpholt @milanvdm


### PR DESCRIPTION
I thought it'd be helpful to have this in place in case new contributors want to tag us on PRs, etc. (I have a couple open PRs in places where I don't know who to tag to get their attention, so I thought it'd be nice to do that here.)